### PR TITLE
Added changes requested by geopandas to clip and vignette

### DIFF
--- a/examples/plot_clip.py
+++ b/examples/plot_clip.py
@@ -11,14 +11,10 @@ of a polygon geometry using GeoPandas.
 # Clip Vector Data in Python Using GeoPandas
 # ---------------------------------------------
 #
-# .. note::
-#    The example below will show you how to use the clip() function to clip
-#    vector data such as points, lines and polygons to a vector boundary.
-#
-# The example below walks you through a typical workflow for clipping one
-# vector data file to the shape of another. Both vector data files must be
-# opened with GeoPandas as GeoDataFrames and be in the same Coordinate
-# Reference System (CRS) for the ``clip_shp()`` function in EarthPy to work.
+# The example below shows you how to clip a set of vector geometries
+# to the spatial extent / shape of another vector object. Both sets of geometries
+# must be opened with GeoPandas as GeoDataFrames and be in the same Coordinate
+# Reference System (CRS) for the ``clip()`` function in EarthPy to work.
 #
 # This example uses Polygons, a Line, and Points made with shapely and then
 # turned into GeoDataframes.
@@ -32,8 +28,7 @@ of a polygon geometry using GeoPandas.
 # Import Packages
 # ---------------
 #
-# To begin, import the needed packages. You will primarily use EarthPy's clip
-# utility alongside GeoPandas.
+# To begin, import the needed packages.
 
 import numpy as np
 import matplotlib.pyplot as plt
@@ -45,29 +40,14 @@ import geopandas.clip as gc
 # Create Example Data
 # -------------------
 #
-# Once the packages have been imported, you need to create the shapes to clip.
-# You need to make two polygons, one line, and one point feature with shapely,
-# and then open those shapes up with GeoPandas.
+# Below, some point, line and polygon geometries are created and coerced into
+# GeoDataFrames to demonstrate the use of clip.
 
 polygon1 = Polygon([(0, 0), (0, 10), (10, 10), (10, 0), (0, 0)])
 polygon2 = Polygon([(-5, -5), (-5, 5), (5, 5), (5, -5), (-5, -5)])
 line = LineString([(3, 4), (5, 7), (12, 2), (10, 5), (9, 7.5)])
 pts = np.array([[2, 2], [3, 4], [9, 8]])
 
-###############################################################################
-# Open Files with GeoPandas and Reproject the Data
-# -------------------------------------------------
-#
-# Open the data files to as GeoDataFrames using GeoPandas.
-#
-# .. note::
-#    Recall that the data must be in the same CRS in order to use the
-#    ``clip()`` function. If the data are not in the same CRS, be sure to use
-#    the ``to_crs()`` function from GeoPandas to match the projects between the
-#    two objects, as shown below. In this example, since you make all of the data,
-#    you don't have to change the CRS.
-
-# Now that since you have all of the shapes created, you can open them with GeoPandas
 poly_gdf1 = gpd.GeoDataFrame(
     [1], geometry=[polygon1], crs={"init": "epsg:4326"}
 )
@@ -80,10 +60,8 @@ points_gdf = gpd.GeoDataFrame(
 )
 
 ###############################################################################
-# The plot below shows all of the data before it has been clipped. Notice that
-# the ``.boundary`` method for a GeoPandas object is used to plot the
-# boundary rather than the filled polygon. This allows for other data, such as
-# the line and point data, to be overlayed on top of the polygon boundary.
+# Plot the Unclipped Data
+# -----------------------
 
 fig, ax = plt.subplots(figsize=(12, 8))
 poly_gdf1.boundary.plot(ax=ax)
@@ -98,15 +76,16 @@ plt.show()
 # Clip the Data
 # --------------
 #
-# Now that the data are opened as GeoDataFrame objects and in the same
-# projection, the data can be clipped! In this example we clip a polygon,
-# a line, and points to a created polygon.
+# When you call ``clip()``, the first object called is the object that will
+# be clipped. The second object called is the clip extent. The returned output
+# will be a new clipped GeoDataframe. All of the attributes for each returned
+# geometry will be retained when you clip.
 #
-# To clip the data, make
-# sure you put the object to be clipped as the first argument in
-# ``clip()``, followed by the vector object (boundary) to which you want
-# the first object clipped. The function will return the clipped GeoDataFrame
-# of the object that is being clipped (e.g. points).
+# .. note::
+#    Recall that the data must be in the same CRS in order to use the
+#    ``clip()`` function. If the data are not in the same CRS, be sure to use
+#    the GeoPandas ``to_crs()`` method to ensure both datasets are in the
+#    same CRS.
 
 ###############################################################################
 # Clip the Polygon Data

--- a/examples/plot_clip.py
+++ b/examples/plot_clip.py
@@ -1,0 +1,156 @@
+"""
+Clip Vector Data with GeoPandas
+==================================================================
+
+Learn how to clip point, line, or polygon geometries to the boundary
+of a polygon geometry using GeoPandas.
+
+"""
+
+###############################################################################
+# Clip Vector Data in Python Using GeoPandas
+# ---------------------------------------------
+#
+# .. note::
+#    The example below will show you how to use the clip() function to clip
+#    vector data such as points, lines and polygons to a vector boundary.
+#
+# The example below walks you through a typical workflow for clipping one
+# vector data file to the shape of another. Both vector data files must be
+# opened with GeoPandas as GeoDataFrames and be in the same Coordinate
+# Reference System (CRS) for the ``clip_shp()`` function in EarthPy to work.
+#
+# This example uses Polygons, a Line, and Points made with shapely and then
+# turned into GeoDataframes.
+#
+# .. note::
+#    The object to be clipped will be clipped to the full extent of the clip
+#    object. If there are multiple polygons in clip object, the input data will
+#    be clipped to the total boundary of all polygons in clip object.
+
+###############################################################################
+# Import Packages
+# ---------------
+#
+# To begin, import the needed packages. You will primarily use EarthPy's clip
+# utility alongside GeoPandas.
+
+import numpy as np
+import matplotlib.pyplot as plt
+import geopandas as gpd
+from shapely.geometry import Polygon, LineString, Point
+import geopandas.clip as gc
+
+###############################################################################
+# Create Example Data
+# -------------------
+#
+# Once the packages have been imported, you need to create the shapes to clip.
+# You need to make two polygons, one line, and one point feature with shapely,
+# and then open those shapes up with GeoPandas.
+
+polygon1 = Polygon([(0, 0), (0, 10), (10, 10), (10, 0), (0, 0)])
+polygon2 = Polygon([(-5, -5), (-5, 5), (5, 5), (5, -5), (-5, -5)])
+line = LineString([(3, 4), (5, 7), (12, 2), (10, 5), (9, 7.5)])
+pts = np.array([[2, 2], [3, 4], [9, 8]])
+
+###############################################################################
+# Open Files with GeoPandas and Reproject the Data
+# -------------------------------------------------
+#
+# Open the data files to as GeoDataFrames using GeoPandas.
+#
+# .. note::
+#    Recall that the data must be in the same CRS in order to use the
+#    ``clip()`` function. If the data are not in the same CRS, be sure to use
+#    the ``to_crs()`` function from GeoPandas to match the projects between the
+#    two objects, as shown below. In this example, since you make all of the data,
+#    you don't have to change the CRS.
+
+# Now that since you have all of the shapes created, you can open them with GeoPandas
+poly_gdf1 = gpd.GeoDataFrame(
+    [1], geometry=[polygon1], crs={"init": "epsg:4326"}
+)
+poly_gdf2 = gpd.GeoDataFrame(
+    [1], geometry=[polygon2], crs={"init": "epsg:4326"}
+)
+line_gdf = gpd.GeoDataFrame([1], geometry=[line], crs={"init": "epsg:4326"})
+points_gdf = gpd.GeoDataFrame(
+    [Point(xy) for xy in pts], columns=["geometry"], crs={"init": "epsg:4326"}
+)
+
+###############################################################################
+# The plot below shows all of the data before it has been clipped. Notice that
+# the ``.boundary`` method for a GeoPandas object is used to plot the
+# boundary rather than the filled polygon. This allows for other data, such as
+# the line and point data, to be overlayed on top of the polygon boundary.
+
+fig, ax = plt.subplots(figsize=(12, 8))
+poly_gdf1.boundary.plot(ax=ax)
+poly_gdf2.boundary.plot(ax=ax, color="red")
+line_gdf.plot(ax=ax, color="green")
+points_gdf.plot(ax=ax, color="purple")
+ax.set_title("All Unclipped Data", fontsize=20)
+ax.set_axis_off()
+plt.show()
+
+###############################################################################
+# Clip the Data
+# --------------
+#
+# Now that the data are opened as GeoDataFrame objects and in the same
+# projection, the data can be clipped! In this example we clip a polygon,
+# a line, and points to a created polygon.
+#
+# To clip the data, make
+# sure you put the object to be clipped as the first argument in
+# ``clip()``, followed by the vector object (boundary) to which you want
+# the first object clipped. The function will return the clipped GeoDataFrame
+# of the object that is being clipped (e.g. points).
+
+###############################################################################
+# Clip the Polygon Data
+# ---------------------
+
+polys_clipped = gc.clip(poly_gdf1, poly_gdf2)
+
+# Plot the clipped data
+# The plot below shows the results of the clip function applied to the polygons
+fig, ax = plt.subplots(figsize=(12, 8))
+polys_clipped.plot(ax=ax, color="purple")
+poly_gdf1.boundary.plot(ax=ax)
+poly_gdf2.boundary.plot(ax=ax, color="red")
+ax.set_title("Polygons Clipped", fontsize=20)
+ax.set_axis_off()
+plt.show()
+
+###############################################################################
+# Clip the Line Data
+# ---------------------
+
+line_clip = gc.clip(poly_gdf1, line_gdf)
+
+# Plot the clipped data
+# The plot below shows the results of the clip function applied to the lines
+# sphinx_gallery_thumbnail_number = 3
+fig, (ax1, ax2) = plt.subplots(1, 2)
+line_gdf.plot(ax=ax1, color="green")
+poly_gdf1.boundary.plot(ax=ax1)
+line_clip.plot(ax=ax2, color="green")
+poly_gdf1.boundary.plot(ax=ax2)
+plt.show()
+
+###############################################################################
+# Clip the Point Data
+# ---------------------
+
+points_clip = gc.clip(poly_gdf2, points_gdf)
+
+# Plot the clipped data
+# The plot below shows the results of the clip function applied to the points
+fig, (ax1, ax2) = plt.subplots(1, 2)
+points_gdf.plot(ax=ax1, color="purple")
+poly_gdf2.boundary.plot(ax=ax1, color="red")
+points_clip.plot(ax=ax2, color="purple")
+poly_gdf2.boundary.plot(ax=ax2, color="red")
+plt.show()

--- a/geopandas/clip.py
+++ b/geopandas/clip.py
@@ -137,7 +137,7 @@ def _clip_multi_poly_line(gdf, clip_obj):
     # Clip multi polygons
     # Explode multi polygons so that intersection works with all parts of the polygon
     # If this step isn't taken, intersection only gets the intersection of one part of the
-    # multi part object. Also reset index to get ride of the column made by explode.
+    # multi part object. Also reset index to remove the column made by explode.
     clipped = _clip_line_poly(gdf.explode().reset_index(level=[1]), clip_obj)
 
     lines = clipped[
@@ -179,7 +179,7 @@ def clip(gdf, clip_obj):
 
     Examples
     --------
-    Clipping points (global capital cities) with a polygon (the South American continent):
+    Clip points (global capital cities) with a polygon (the South American continent):
 
         >>> import geopandas as gpd
         >>> import geopandas.clip as gc

--- a/geopandas/clip.py
+++ b/geopandas/clip.py
@@ -179,38 +179,18 @@ def clip(gdf, clip_obj):
 
     Examples
     --------
-    Clipping points (glacier locations in the state of Colorado) with
-    a polygon (the boundary of Rocky Mountain National Park):
+    Clipping points (global capital cities) with a polygon (the South American continent):
 
         >>> import geopandas as gpd
-        >>> import earthpy.clip as cl
-        >>> from earthpy.io import path_to_example
-        >>> rmnp = gpd.read_file(path_to_example('rmnp.gdf'))
-        >>> glaciers = gpd.read_file(path_to_example('colorado-glaciers.geojson'))
-        >>> glaciers.shape
-        (134, 2)
-        >>> rmnp_glaciers = cl.clip(glaciers, rmnp)
-        >>> rmnp_glaciers.shape
-        (36, 2)
-
-    Clipping a line (the Continental Divide Trail) with a
-    polygon (the boundary of Rocky Mountain National Park):
-
-        >>> cdt = gpd.read_file(path_to_example('continental-div-trail.geojson'))
-        >>> rmnp_cdt_section = cl.clip(cdt, rmnp)
-        >>> cdt['geometry'].length > rmnp_cdt_section['geometry'].length
-        0    True
-        dtype: bool
-
-    Clipping a polygon (Colorado counties) with another polygon
-    (the boundary of Rocky Mountain National Park):
-
-        >>> counties = gpd.read_file(path_to_example('colorado-counties.geojson'))
-        >>> counties.shape
-        (64, 13)
-        >>> rmnp_counties = cl.clip(counties, rmnp)
-        >>> rmnp_counties.shape
-        (4, 13)
+        >>> import geopandas.clip as gc
+        >>> world = geopandas.read_file(geopandas.datasets.get_path('naturalearth_lowres'))
+        >>> south_america = world[world['continent'] == "South America"]
+        >>> capitals = gpd.read_file(gpd.datasets.get_path('naturalearth_cities'))
+        >>> capitals.shape
+        (202, 2)
+        >>> sa_capitals = cl.clip(capitals, south_america)
+        >>> sa_capitals.shape
+        (12, 2)
     """
     if not isinstance(gdf, (gpd.GeoDataFrame, gpd.GeoSeries)) and isinstance(clip_obj, (gpd.GeoDataFrame, gpd.GeoSeries)):
         raise AttributeError(


### PR DESCRIPTION
Added in the changes that were requested in the GeoPandas PR and also added the updated vignette. The example data they recommended  was only really able to show a good example of clipping points to a polygon. I could buffer the points and clip them again to show how to clip a polygon, or I could use custom made data in the example section of the clip function. For the vignette I used custom made data.