### PR TITLE
Ensure data are sorted according to original pre-clip order

### DIFF
--- a/geopandas/clip.py
+++ b/geopandas/clip.py
@@ -255,5 +255,5 @@ def clip(gdf, clip_obj):
 
     order = pd.Series(range(len(gdf)), index=gdf.index)
     concat = pd.concat([multipoint_gdf, point_gdf, multipoly_line_gdf, poly_line_gdf])
-    concat['_order'] = order
-    return concat.sort_values(by='_order').drop(columns='_order')
+    concat["_order"] = order
+    return concat.sort_values(by="_order").drop(columns="_order")

--- a/geopandas/clip.py
+++ b/geopandas/clip.py
@@ -253,4 +253,7 @@ def clip(gdf, clip_obj):
     else:
         poly_line_gdf = None
 
-    return pd.concat([multipoint_gdf, point_gdf, multipoly_line_gdf, poly_line_gdf])
+    order = pd.Series(range(len(gdf)), index=gdf.index)
+    concat = pd.concat([multipoint_gdf, point_gdf, multipoly_line_gdf, poly_line_gdf])
+    concat['_order'] = order
+    return concat.sort_values(by='_order').drop(columns='_order')


### PR DESCRIPTION
Added in the concat changes recommended in order to preserve geometry order.

This addresses this comment: https://github.com/geopandas/geopandas/pull/1128#discussion_r347019334 related to data sort post clip