### PR TITLE
Limit sliver uses

### DIFF
--- a/geopandas/tests/test_clip.py
+++ b/geopandas/tests/test_clip.py
@@ -12,17 +12,17 @@ import warnings
 
 @pytest.fixture
 def point_gdf():
-    """ Create a point GeoDataFrame. """
+    """Create a point GeoDataFrame."""
     pts = np.array([[2, 2], [3, 4], [9, 8], [-12, -15]])
     gdf = GeoDataFrame(
-        [Point(xy) for xy in pts], columns=["geometry"], crs={"init": "epsg:4326"}
+        [Point(xy) for xy in pts], columns=["geometry"], crs={"init": "epsg:4326"},
     )
     return gdf
 
 
 @pytest.fixture
 def single_rectangle_gdf():
-    """Create a single rectangle for clipping. """
+    """Create a single rectangle for clipping."""
     poly_inters = Polygon([(0, 0), (0, 10), (10, 10), (10, 0), (0, 0)])
     gdf = GeoDataFrame([1], geometry=[poly_inters], crs={"init": "epsg:4326"})
     gdf["attr2"] = "site-boundary"
@@ -32,7 +32,6 @@ def single_rectangle_gdf():
 @pytest.fixture
 def larger_single_rectangle_gdf():
     """Create a slightly larger rectangle for clipping.
-
      The smaller single rectangle is used to test the edge case where slivers
      are returned when you clip polygons. This fixture is larger which
      eliminates the slivers in the clip return."""
@@ -44,7 +43,7 @@ def larger_single_rectangle_gdf():
 
 @pytest.fixture
 def buffered_locations(point_gdf):
-    """Buffer points to create a multi-polygon. """
+    """Buffer points to create a multi-polygon."""
     buffered_locs = point_gdf
     buffered_locs["geometry"] = buffered_locs.buffer(4)
     buffered_locs["type"] = "plot"
@@ -53,7 +52,7 @@ def buffered_locations(point_gdf):
 
 @pytest.fixture
 def donut_geometry(buffered_locations, single_rectangle_gdf):
-    """ Make a geometry with a hole in the middle (a donut). """
+    """Make a geometry with a hole in the middle (a donut)."""
     donut = gpd.overlay(
         buffered_locations, single_rectangle_gdf, how="symmetric_difference"
     )
@@ -62,7 +61,7 @@ def donut_geometry(buffered_locations, single_rectangle_gdf):
 
 @pytest.fixture
 def two_line_gdf():
-    """ Create Line Objects For Testing """
+    """Create Line Objects For Testing"""
     linea = LineString([(1, 1), (2, 2), (3, 2), (5, 3)])
     lineb = LineString([(3, 4), (5, 7), (12, 2), (10, 5), (9, 7.5)])
     gdf = GeoDataFrame([1, 2], geometry=[linea, lineb], crs={"init": "epsg:4326"})
@@ -71,7 +70,7 @@ def two_line_gdf():
 
 @pytest.fixture
 def multi_poly_gdf(donut_geometry):
-    """ Create a multi-polygon GeoDataFrame. """
+    """Create a multi-polygon GeoDataFrame."""
     multi_poly = donut_geometry.unary_union
     out_df = GeoDataFrame(geometry=gpd.GeoSeries(multi_poly), crs={"init": "epsg:4326"})
     out_df["attr"] = ["pool"]
@@ -80,15 +79,13 @@ def multi_poly_gdf(donut_geometry):
 
 @pytest.fixture
 def multi_line(two_line_gdf):
-    """ Create a multi-line GeoDataFrame.
-
-    This GDF has one multiline and one regular line.
-    """
+    """Create a multi-line GeoDataFrame.
+    This GDF has one multiline and one regular line."""
     # Create a single and multi line object
     multiline_feat = two_line_gdf.unary_union
     linec = LineString([(2, 1), (3, 1), (4, 1), (5, 2)])
     out_df = GeoDataFrame(
-        geometry=gpd.GeoSeries([multiline_feat, linec]), crs={"init": "epsg:4326"}
+        geometry=gpd.GeoSeries([multiline_feat, linec]), crs={"init": "epsg:4326"},
     )
     out_df["attr"] = ["road", "stream"]
     return out_df
@@ -96,7 +93,7 @@ def multi_line(two_line_gdf):
 
 @pytest.fixture
 def multi_point(point_gdf):
-    """ Create a multi-point GeoDataFrame. """
+    """Create a multi-point GeoDataFrame."""
     multi_point = point_gdf.unary_union
     out_df = GeoDataFrame(
         geometry=gpd.GeoSeries(
@@ -110,7 +107,7 @@ def multi_point(point_gdf):
 
 @pytest.fixture
 def mixed_gdf():
-    """ Create a Mixed Polygon and LineString For Testing """
+    """Create a Mixed Polygon and LineString For Testing"""
     point = Point([(2, 3), (11, 4), (7, 2), (8, 9), (1, 13)])
     line = LineString([(1, 1), (2, 2), (3, 2), (5, 3), (12, 1)])
     poly = Polygon([(3, 4), (5, 2), (12, 2), (10, 5), (9, 7.5)])
@@ -178,9 +175,8 @@ def test_clip_poly(buffered_locations, single_rectangle_gdf):
 
 def test_clip_multipoly_keep_slivers(multi_poly_gdf, single_rectangle_gdf):
     """Test a multi poly object where the return includes a sliver.
-
     Also the bounds of the object should == the bounds of the clip object
-    if they fully overlap (as they do in these fixtures). """
+    if they fully overlap (as they do in these fixtures)."""
     with pytest.warns(UserWarning):
         clip = gpd.clip(multi_poly_gdf, single_rectangle_gdf)
         warnings.warn("A geometry collection has been returned. ", UserWarning)
@@ -192,9 +188,8 @@ def test_clip_multipoly_keep_slivers(multi_poly_gdf, single_rectangle_gdf):
 
 def test_clip_multipoly_drop_slivers(multi_poly_gdf, single_rectangle_gdf):
     """Test a multi poly object where the return includes a sliver.
-
     Also the bounds of the object should == the bounds of the clip object
-    if they fully overlap (as they do in these fixtures). """
+    if they fully overlap (as they do in these fixtures)."""
     clip = gpd.clip(multi_poly_gdf, single_rectangle_gdf, drop_slivers=True)
     assert hasattr(clip, "geometry")
     assert np.array_equal(clip.total_bounds, single_rectangle_gdf.total_bounds)
@@ -204,7 +199,6 @@ def test_clip_multipoly_drop_slivers(multi_poly_gdf, single_rectangle_gdf):
 
 def test_clip_multipoly_warning(multi_poly_gdf, single_rectangle_gdf):
     """Test that a user warning is provided when clip outputs a sliver."""
-
     with pytest.warns(UserWarning):
         gpd.clip(multi_poly_gdf, single_rectangle_gdf)
         warnings.warn("A geometry collection has been returned. ", UserWarning)
@@ -213,10 +207,8 @@ def test_clip_multipoly_warning(multi_poly_gdf, single_rectangle_gdf):
 def test_clip_single_multipoly_no_slivers(
     buffered_locations, larger_single_rectangle_gdf
 ):
-    """Test clipping a multi poly with another poly
-
-    No sliver shapes are returned in this clip operation. """
-
+    """Test clipping a multi poly with another poly no sliver
+    shapes are returned in this clip operation."""
     multi = buffered_locations.dissolve(by="type").reset_index()
     clip = gpd.clip(multi, larger_single_rectangle_gdf)
 
@@ -225,18 +217,14 @@ def test_clip_single_multipoly_no_slivers(
 
 def test_clip_multiline(multi_line, single_rectangle_gdf):
     """Test that clipping a multiline feature with a poly returns expected output."""
-
     clip = gpd.clip(multi_line, single_rectangle_gdf)
     assert hasattr(clip, "geometry") and clip.geom_type[0] == "MultiLineString"
 
 
 def test_clip_multipoint(single_rectangle_gdf, multi_point):
     """Clipping a multipoint feature with a polygon works as expected.
-
     should return a geodataframe with a single multi point feature"""
-
     clip = gpd.clip(multi_point, single_rectangle_gdf)
-
     assert hasattr(clip, "geometry") and clip.geom_type[0] == "MultiPoint"
     assert hasattr(clip, "attr")
     # All points should intersect the clip geom
@@ -291,10 +279,11 @@ def test_clip_with_line_sliver(single_rectangle_gdf, sliver_line):
 
 
 def test_clip_line_keep_slivers(single_rectangle_gdf, sliver_line):
+    """Test the correct warnings are raised if a point sliver is returned"""
     with pytest.warns(UserWarning):
         clip = gpd.clip(sliver_line, single_rectangle_gdf)
         warnings.warn(
-            "More geometry types were returned than were in the original ", UserWarning
+            "More geometry types were returned than were in the original ", UserWarning,
         )
         assert hasattr(clip, "geometry")
         # Assert returned data is a geometry collection given sliver geoms
@@ -303,6 +292,7 @@ def test_clip_line_keep_slivers(single_rectangle_gdf, sliver_line):
 
 
 def test_warning_slivers_mixed(single_rectangle_gdf, mixed_gdf):
+    """Test the correct warnings are raised if drop_slivers is called on a mixed GDF"""
     with pytest.warns(UserWarning):
         gpd.clip(mixed_gdf, single_rectangle_gdf)
         warnings.warn("Drop slivers was called on a mixed type GeoDataFrame.")

--- a/geopandas/tests/test_clip.py
+++ b/geopandas/tests/test_clip.py
@@ -293,7 +293,9 @@ def test_clip_with_line_sliver(single_rectangle_gdf, sliver_line):
 def test_clip_line_keep_slivers(single_rectangle_gdf, sliver_line):
     with pytest.warns(UserWarning):
         clip = gpd.clip(sliver_line, single_rectangle_gdf)
-        warnings.warn("More geometry types were returned than were in the original ", UserWarning)
+        warnings.warn(
+            "More geometry types were returned than were in the original ", UserWarning
+        )
         assert hasattr(clip, "geometry")
         # Assert returned data is a geometry collection given sliver geoms
         assert "Point" == clip.geom_type[0]

--- a/geopandas/tools/clip.py
+++ b/geopandas/tools/clip.py
@@ -180,25 +180,53 @@ def clip(gdf, clip_obj, drop_slivers=False):
     order = pd.Series(range(len(gdf)), index=gdf.index)
     concat = pd.concat([point_gdf, line_gdf, poly_gdf])
 
-    if (concat.geom_type == "GeometryCollection").any() and drop_slivers:
-        concat = concat.explode()
-        if not polys.empty:
-            concat = concat.loc[concat.geom_type.isin(["Polygon", "MultiPolygon"])]
-        elif not lines.empty:
-            concat = concat.loc[
-                concat.geom_type.isin(["LineString", "MultiLineString", "LinearRing"])
-            ]
-        elif not points.empty:
-            concat = concat.loc[concat.geom_type.isin(["Point", "MultiPoint"])]
-        else:
-            raise TypeError("`drop_sliver` does not support {}.".format(type))
-    elif (concat.geom_type == "GeometryCollection").any() and not drop_slivers:
+    polys = ["Polygon", "MultiPolygon"]
+    lines = ["LineString", "MultiLineString", "LinearRing"]
+    points = ["Point", "MultiPoint"]
+
+    poly_check_orig = gdf.geom_type.isin(polys).any()
+    lines_check_orig = gdf.geom_type.isin(lines).any()
+    points_check_orig = gdf.geom_type.isin(points).any()
+
+    orig_types_total = sum([poly_check_orig, lines_check_orig, points_check_orig])
+
+    poly_check_clip = concat.geom_type.isin(polys).any()
+    lines_check_clip = concat.geom_type.isin(lines).any()
+    points_check_clip = concat.geom_type.isin(points).any()
+
+    clip_types_total = sum([poly_check_clip, lines_check_clip, points_check_clip])
+
+    geometry_collection = (concat.geom_type == "GeometryCollection").any()
+
+    more_types = orig_types_total < clip_types_total
+
+    if orig_types_total > 1 and drop_slivers:
+        warnings.warn(
+            "Drop slivers was called on a mixed type GeoDataFrame. "
+            "Slivers cannot be dropped on mixed type GeoDataFrames. "
+            "The data will be return with slivers present."
+        )
+    elif drop_slivers and not geometry_collection and not more_types:
+        warnings.warn("Drop slivers was called when no slivers existed.")
+    elif drop_slivers and (geometry_collection or more_types):
+        orig_type = gdf.geom_type.iloc[0]
+        if geometry_collection:
+            concat = concat.explode()
+        if orig_type in polys:
+            concat = concat.loc[concat.geom_type.isin(polys)]
+        elif orig_type in lines:
+            concat = concat.loc[concat.geom_type.isin(lines)]
+    elif geometry_collection and not drop_slivers:
         warnings.warn(
             "A geometry collection has been returned. Use .explode() to "
             "remove the collection object or drop_slivers=True to remove "
             "sliver geometries."
         )
-    elif drop_slivers:
-        warnings.warn("Drop slivers was called when no slivers existed.")
+    elif more_types and not drop_slivers:
+        warnings.warn(
+            "More geometry types were returned than were in the original "
+            "GeoDataFrame. This is likely due to a sliver being created. "
+            "To remove the slivers set drop_slivers=True. "
+        )
     concat["_order"] = order
     return concat.sort_values(by="_order").drop(columns="_order")

--- a/geopandas/tools/clip.py
+++ b/geopandas/tools/clip.py
@@ -129,14 +129,10 @@ def clip(gdf, clip_obj, drop_slivers=False):
     """
     if not isinstance(gdf, (GeoDataFrame, GeoSeries)):
         raise TypeError(
-            "'gdf' should be GeoDataFrame or GeoSeries, got {}".format(
-                type(gdf)
-            )
+            "'gdf' should be GeoDataFrame or GeoSeries, got {}".format(type(gdf))
         )
 
-    if not isinstance(
-        clip_obj, (GeoDataFrame, GeoSeries, Polygon, MultiPolygon)
-    ):
+    if not isinstance(clip_obj, (GeoDataFrame, GeoSeries, Polygon, MultiPolygon)):
         raise TypeError(
             "'clip_obj' should be GeoDataFrame, GeoSeries or"
             "(Multi)Polygon, got {}".format(type(gdf))
@@ -155,17 +151,13 @@ def clip(gdf, clip_obj, drop_slivers=False):
         poly = clip_obj
 
     geom_types = gdf.geometry.type
-    poly_idx = np.asarray(
-        (geom_types == "Polygon") | (geom_types == "MultiPolygon")
-    )
+    poly_idx = np.asarray((geom_types == "Polygon") | (geom_types == "MultiPolygon"))
     line_idx = np.asarray(
         (geom_types == "LineString")
         | (geom_types == "LinearRing")
         | (geom_types == "MultiLineString")
     )
-    point_idx = np.asarray(
-        (geom_types == "Point") | (geom_types == "MultiPoint")
-    )
+    point_idx = np.asarray((geom_types == "Point") | (geom_types == "MultiPoint"))
 
     points = gdf[point_idx]
     if not points.empty:


### PR DESCRIPTION
Limited `drop_slivers` to only be used on single type `polygon` or `line` geodataframes. Additionally, made `drop_slivers` work when a sliver is returned not as a geodataframe, which is apparently possible. This is the behavior when a line returns a point sliver. It doesn't return a geometry collection, just a regular geodataframe with a line and a point in it. So, I added the needed sections and warnings to check for those cases. 